### PR TITLE
Test imports of Qt-based modules

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,8 @@ test:
     - pytest
   imports:
     - glue
+    - glue.core
+    - glue.app.qt
   commands:
     - glue --version
     - glue-deps list


### PR DESCRIPTION
To make sure we avoid or at least test for https://github.com/conda-forge/pyqt-feedstock/issues/5 once glue 0.9 is released.
