### PR TITLE
Build the package even though it is empty

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,8 @@ source:
   md5: 94f1774e3c379403966ca217bbe36d7a
 
 build:
-  number: 0
+  number: 1
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
 


### PR DESCRIPTION
Build the package, since otherwise users can run into issues if they pip install glueviz while a conda version is also installed, since the pip glueviz package would get picked up, but the conda glue-core one would take precedence, potentially causing version incompatibilities.